### PR TITLE
Vertikale Ausrichtung im mobilen Hauptmenü

### DIFF
--- a/stylesheets/app.css
+++ b/stylesheets/app.css
@@ -137,7 +137,7 @@ div.mejs-container {
 }
 
 /* <nav> */
-.top-bar { background: transparent; height: 35px; line-height: 35px; }
+.top-bar { background: transparent; line-height: 35px; }
 .top-bar ul, .top-bar ul li { background-color: #dc0067; height: auto; }
 .top-bar ul > li a:not(.button) { color: #ffffff; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-size: 14px; font-weight: bold; }
 .top-bar ul > li:hover, .top-bar ul > li:active { background-color: #900043; }


### PR DESCRIPTION
In der mobilen Ansicht wird der Text im Hauptmenü (z.B. _Home_) vertikal falsch ausgerichtet. 

<img width="387" alt="bildschirmfoto 2016-04-17 um 10 51 40" src="https://cloud.githubusercontent.com/assets/1202880/14586016/78fd4c58-048a-11e6-9433-8156881c2b71.png">

Durch Entfernen der fixen Höhe (die sonst wohl nicht weiter benötigt wird) sollte sich das lösen.
